### PR TITLE
Fixed typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 - [Websites](#websites)
   - [Wiki](#wiki)
   - [Forums](#forums)
-- [Mod Loader](#mod-loader)
+- [Mod Loaders](#mod-loaders)
 - [Forge Mods](#forge-mods)
   - [Performance](#performance)
   - [Skins And Capes](#skins-and-capes)


### PR DESCRIPTION
The shortcut to the mod loaders section wasn't working due to a missing "s"