### PR TITLE
Add Shard Launcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,8 @@
 - [Prism](https://prismlauncher.org) - A fork of MultiMC, capable of downloading modpacks and other resources directly from CurseForge and FTB.
 - [HMCL](https://github.com/huanghongxun/HMCL) - A powered Minecraft launcher that supports a lot of features.
 - [XMCL](https://github.com/Voxelum/x-minecraft-launcher) - X Minecraft Launcher (XMCL) is a modern Minecraft launcher that lets you manage your massive resources like modpacks, resource packs, mods and shader packs.
-- [Polymerium](https://github.com/d3ara1n/Polymerium) - 🐿️ A next-generation Minecraft instance manager that thinks differently about game management.
+- [Polymerium](https://github.com/d3ara1n/Polymerium) - A next-generation Minecraft instance manager that thinks differently about game management.
+- [Shard Launcher](https://shard.thomas.md) - An open-source Minecraft launcher with declarative profiles, content-addressed storage, and Modrinth/CurseForge integration.
 
 ## Development
 


### PR DESCRIPTION
Added Shard Launcher to the Launchers section.

Shard is an open-source Minecraft launcher with declarative JSON profiles, content-addressed storage for deduplication, and Modrinth/CurseForge integration.

Website: https://shard.thomas.md
Source: https://github.com/Th0rgal/shard

Thank you for maintaining this list.