### PR TITLE
Add MoonProxy to Softwares > Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -238,6 +238,7 @@
 
 - [Minecraft Command Helper](https://github.com/IceLitty/Minecraft-Command-Helper) - A WPF Program about generate Minecraft Command (with NBT data). (Windows Only)
 - [Minecraft Command Science](https://minecraftcommand.science/) - Several Minecraft vanilla JSON generators.
+- [MoonProxy](https://moonproxy.app) - A desktop GUI client for FRP (intranet penetration / remote access), making it easy to expose a local Minecraft server to friends. ([Source Code](https://github.com/MoonProxyHQ/moonproxy-desktop))
 - [Amidst](https://github.com/toolbox4minecraft/amidst) - Display an overview of a Minecraft world, without actually creating it.
 - [Amulet](https://github.com/Amulet-Team/Amulet-Map-Editor) - Map viewer/editor.
 - [NBTEditor](https://github.com/Howaner/NBTEditor) - Edit NBT from .dat files.


### PR DESCRIPTION
## What is MoonProxy?

MoonProxy is a desktop GUI client for FRP (Fast Reverse Proxy), an intranet penetration / remote access tool. It makes it easy to expose a local Minecraft server to friends over the internet without needing port forwarding or a static IP.

- **Website:** https://moonproxy.app
- **Source Code:** https://github.com/MoonProxyHQ/moonproxy-desktop
- **License:** MIT
- **Platforms:** macOS, Windows

## Why this category?

Placed under **Softwares > Utilities** alongside other Minecraft helper tools. MoonProxy is commonly used by players running a local Minecraft server to let friends connect remotely (内网穿透), making it a natural fit for the server-management / connectivity utilities.

## Checklist

- [x] By selecting the correct category, this entry is not a duplicate.
- [x] The project is open source or has a freely accessible website.
- [x] Description follows the existing entry style (`- [Name](url) - Description.`).