### PR TITLE
Add BlockMosaic to Web Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@
 
 - [Blessing Skin Server](https://github.com/bs-community/blessing-skin-server) - A web application brings your custom skins back in offline Minecraft servers.
 - [WorldEdit Golf](https://worldedit.golf/) - Challenge others in a competition to use WorldEdit in as few commands as possible.
+- [BlockMosaic](https://mcimagetool.com) - Web app (browser, client-side) that converts images into Minecraft pixel art / map art, with block shopping lists and .litematic/.schem schematic export.
 
 ## Softwares
 


### PR DESCRIPTION
Adds BlockMosaic (mcimagetool.com) to Web Applications — a browser-based, client-side web app that converts images into Minecraft pixel art / map art, with block shopping lists and .litematic/.schem schematic export. Per the contributing guide: platform is Web (browser, client-side, no install).