### PR TITLE
Add Best Minecraft ID to Web Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@
 
 - [Blessing Skin Server](https://github.com/bs-community/blessing-skin-server) - A web application brings your custom skins back in offline Minecraft servers.
 - [WorldEdit Golf](https://worldedit.golf/) - Challenge others in a competition to use WorldEdit in as few commands as possible.
+- [Best Minecraft ID](https://bestminecraftid.com/) - Minecraft Java Edition ID database with 1,500+ searchable items, block/enchantment/effect/entity/biome ID lists, and /give command generator. (Web application)
 
 ## Softwares
 


### PR DESCRIPTION
- **Resource**: Best Minecraft ID
- **URL**: https://bestminecraftid.com/
- **Category**: Web Applications
- **Platform**: Web application (static site)
- **Description**: Free Minecraft Java Edition ID database covering 1,500+ searchable items, with block/enchantment/effect/entity/biome/sound/particle ID lists, interactive /give command generator, color code chart, and legacy 1.12.2 numerical IDs.
- **Why include**: Fills the gap between the official wiki (too broad) and existing ID sites (outdated or poor UX). Actively maintained, no paywall.