### PR TITLE
Add MinecraftSearch Seed Map to Web Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,8 @@
 
 - [Blessing Skin Server](https://github.com/bs-community/blessing-skin-server) - A web application brings your custom skins back in offline Minecraft servers.
 - [WorldEdit Golf](https://worldedit.golf/) - Challenge others in a competition to use WorldEdit in as few commands as possible.
+- [MinecraftSearch Seed Map](https://minecraftsearch.com/tools/seed-map) - Web-based seed map for Java and Bedrock,
+  showing biomes, structures and ores with shareable links.
 
 ## Softwares
 


### PR DESCRIPTION
Adds a browser seed map to Web Applications — the list currently has no seed tool of any kind. Java and Bedrock, Overworld/Nether/End, no download or account. Disclosure: I'm the author.