### PR TITLE
Add CraftQuiver to Web Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@
 ## Web Applications
 
 - [Blessing Skin Server](https://github.com/bs-community/blessing-skin-server) - A web application brings your custom skins back in offline Minecraft servers.
+- [CraftQuiver](https://craftquiver.com/) - Crafting recipe reference with a material calculator for any item and quantity, shareable resource lists, an anvil enchantment cost optimizer and a Nether/Overworld coordinate converter.
 - [WorldEdit Golf](https://worldedit.golf/) - Challenge others in a competition to use WorldEdit in as few commands as possible.
 
 ## Softwares


### PR DESCRIPTION
Adding CraftQuiver (https://craftquiver.com/) under Web Applications.
It's a free browser tool for Minecraft Java Edition:
- Interactive crafting recipe reference
- Material calculator — enter an item and quantity, get the full raw-material breakdown
- Shareable resource lists
- Cheapest anvil step ordering for enchantments
- Nether/Overworld coordinate converter
No signup, no paywall, no ads. I'm the author.