### PR TITLE
Add ServerBuddy web application

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@
 ## Web Applications
 
 - [Blessing Skin Server](https://github.com/bs-community/blessing-skin-server) - A web application brings your custom skins back in offline Minecraft servers.
+- [ServerBuddy](https://serverbuddy.net/) - Web app for discovering Java and Bedrock servers with live status, player-count history, uptime, MOTD and version history, and browser-based server tools.
 - [WorldEdit Golf](https://worldedit.golf/) - Challenge others in a competition to use WorldEdit in as few commands as possible.
 
 ## Softwares


### PR DESCRIPTION
## Summary

- add ServerBuddy to the Web Applications section
- describe its Java and Bedrock server discovery, history, and browser-tool features
- link to the canonical ServerBuddy homepage

## Validation

- confirmed https://serverbuddy.net returns HTTP 200
- confirmed ServerBuddy was not already listed
- ran git diff --check
- kept the existing Markdown list format and identified it as a web app per the contribution guide